### PR TITLE
Identify Captcha request

### DIFF
--- a/degiro_connector/core/exceptions.py
+++ b/degiro_connector/core/exceptions.py
@@ -22,3 +22,15 @@ class MaintenanceError(DeGiroConnectionError):
             error_details (LoginError): The login error details
         """
         super().__init__(message, error_details)
+
+class CaptchaRequiredError(DeGiroConnectionError):
+    """Exception raised when DeGiro requires a captcha."""
+    def __init__(self, message, error_details):
+        """
+        Initializes the exception with a message and a structure of error details.
+
+        Args:
+            message (str): The error message.
+            error_details (LoginError): The login error details
+        """
+        super().__init__(message, error_details)

--- a/degiro_connector/trading/actions/action_connect.py
+++ b/degiro_connector/trading/actions/action_connect.py
@@ -1,6 +1,6 @@
 import logging
 
-from degiro_connector.core.exceptions import DeGiroConnectionError, MaintenanceError
+from degiro_connector.core.exceptions import CaptchaRequiredError, DeGiroConnectionError, MaintenanceError
 from html.parser import HTMLParser
 import pyotp
 import requests
@@ -107,11 +107,18 @@ class ActionConnect(AbstractAction):
                 login_error.model_dump(mode="python", by_alias=True, exclude_none=True),
             )
 
-        if login_error and login_error.status == 6:
-            raise DeGiroConnectionError('2FA is enabled, please provide the "totp_secret".', login_error)
+        if login_error:
+            if login_error.captcha_required:
+                raise CaptchaRequiredError(
+                    "Captcha required. Login to DEGIRO via the browser and solve the captcha.",
+                    login_error,
+                )
 
-        if login_error and login_error.status == 405:
-            raise MaintenanceError('Scheduled Maintenance.', login_error)
+            if login_error.status == 6:
+                raise DeGiroConnectionError('2FA is enabled, please provide the "totp_secret".', login_error)
+
+            if login_error.status == 405:
+                raise MaintenanceError('Scheduled Maintenance.', login_error)
 
         if login_sucess is None:
             raise DeGiroConnectionError("No session id returned.", login_error)

--- a/degiro_connector/trading/models/login.py
+++ b/degiro_connector/trading/models/login.py
@@ -29,6 +29,7 @@ class LoginError(BaseModel):
     status: int
     status_text: str | None = Field(default=None)
     timestamp: date | None = Field(default=None)
+    captcha_required: bool | None = Field(default=None)
 
 
 class Login(BaseModel):


### PR DESCRIPTION
If the credentials are wrongly introduced too many times, DEGIRO may force to login via the web, doing a captcha challenge.

The only way to identify this issue is with the `captcha_required` field provided with the error. Otherwise, it looks like a normal error.